### PR TITLE
feat(auth): hide back button if navigator cannot pop

### DIFF
--- a/packages/firebase_ui_auth/lib/src/views/phone_input_view.dart
+++ b/packages/firebase_ui_auth/lib/src/views/phone_input_view.dart
@@ -141,14 +141,16 @@ class _PhoneInputViewState extends State<PhoneInputView> {
               ErrorText(exception: state.exception),
               const SizedBox(height: 8),
             ],
-            const SizedBox(height: 8),
-            UniversalButton(
-              text: l.goBackButtonLabel,
-              variant: ButtonVariant.text,
-              onPressed: () {
-                Navigator.of(context).pop();
-              },
-            ),
+            if (Navigator.of(context).canPop()) ...[
+              const SizedBox(height: 8),
+              UniversalButton(
+                text: l.goBackButtonLabel,
+                variant: ButtonVariant.text,
+                onPressed: () {
+                  Navigator.of(context).pop();
+                },
+              ),
+            ],
             if (widget.footerBuilder != null) widget.footerBuilder!(context),
           ],
         );


### PR DESCRIPTION
## Summary
- only show the back button on `PhoneInputView` when there is a route to pop

## Testing
- `melos run format` *(fails: command not found)*
- `melos run analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685031e79d448331a98160677c680c0c